### PR TITLE
Fix misuse of `tr` causing issues in specific conditions

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,8 +19,8 @@ fi
 
 for var in $(env)
 do
-  ENV_VAR_KEY="\$$(echo "$var" | tr "=" " " | awk '{print $1}')"
-  ENV_VAR_VALUE=$(echo "$var" | tr "$ENV_VAR_KEY=" " " | awk '{print $1}')
+  ENV_VAR_KEY="\$$(echo "$var" | cut -d= -f1)"
+  ENV_VAR_VALUE=$(echo "$var" | cut -d= -f2-)
 
   case "$ENV_VAR_VALUE" in
   *.*)


### PR DESCRIPTION
When parsing the env, `tr` is used to extract the key name from its value, by removing the `VAR_NAME=` part and replacing it by whitespace.

Problem is, `tr` will replace all characters present in its first arg by the value in the second arg, it does not search for the substring.

So if a character is present in the var name as well as the value, it will also be replaced by a whitespace and cause issues.

This PR replaces the parsing by using `cut`